### PR TITLE
Add preshared key (PSK) to peer configuration

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,5 +15,5 @@ rustPlatform.buildRustPackage rec {
     gtk4.dev
   ];
 
-  cargoSha256 = "sha256-rV+GAOd3BmbMZKDKRDFNzrSbi5IqptNoFo9wHRDBPT0=";
+  cargoSha256 = "sha256-XO/saJfdiawN8CF6oF5HqrvLBllNueFUiE+7A7XWC5M=";
 }

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,8 @@
       let pkgs = nixpkgs.legacyPackages.${system}; in
       {
         packages = rec {
-          wireguird = pkgs.callPackage ./default.nix {};
-          default = wireguird;
+          wireguard-gui = pkgs.callPackage ./default.nix {};
+          default = wireguard-gui;
         };
 
         devShells.default = import ./shell.nix {inherit pkgs;};

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ pub struct Peer {
     pub allowed_ips: Option<String>,
     pub endpoint: Option<String>,
     pub public_key: Option<String>,
+    pub preshared_key: Option<String>,
     pub persistent_keepalive: Option<String>,
 }
 
@@ -112,6 +113,7 @@ pub fn parse_config(s: &str) -> Result<WireguardConfig, String> {
                         "AllowedIPs" => tmp_peer.allowed_ips = Some(value),
                         "Endpoint" => tmp_peer.endpoint = Some(value),
                         "PublicKey" => tmp_peer.public_key = Some(value),
+                        "PresharedKey" => tmp_peer.preshared_key = Some(value),
                         "PersistentKeepalive" => tmp_peer.persistent_keepalive = Some(value),
                         k => return Err(format!("Unexpected Peer configuration key {}.", k)),
                     };
@@ -169,6 +171,7 @@ pub fn write_config(c: &WireguardConfig) -> String {
             peer.allowed_ips.clone().map(|v| ("AllowedIPs", v)),
             peer.endpoint.clone().map(|v| ("Endpoint", v)),
             peer.public_key.clone().map(|v| ("PublicKey", v)),
+            peer.preshared_key.clone().map(|v| ("PresharedKey", v)),
             peer.persistent_keepalive
                 .clone()
                 .map(|v| ("PersistentKeepalive", v)),

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -4,6 +4,7 @@ use relm4::{gtk::prelude::*, prelude::*};
 
 use crate::config::*;
 use crate::peer::*;
+use crate::utils::*;
 
 pub struct OverviewModel {
     interface: Interface,
@@ -66,12 +67,12 @@ impl SimpleComponent for OverviewModel {
                     set_column_spacing: 5,
                     set_margin_all: 5,
 
-                    attach[0, 0, 1, 1] = &gtk::Label {
+                    attach[1, 0, 1, 1] = &gtk::Label {
                         set_label: "# Name:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "name"]
-                    attach[1, 0, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 0, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.name),
                         connect_editing_notify[sender] => move |l| {
@@ -82,12 +83,12 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 1, 1, 1] = &gtk::Label {
+                    attach[1, 1, 1, 1] = &gtk::Label {
                         set_label: "Address:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "address"]
-                    attach[1, 1, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 1, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.address),
                         connect_editing_notify[sender] => move |l| {
@@ -98,12 +99,12 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 2, 1, 1] = &gtk::Label {
+                    attach[1, 2, 1, 1] = &gtk::Label {
                         set_label: "ListenPort:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "listen_port"]
-                    attach[1, 2, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 2, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.listen_port),
                         connect_editing_notify[sender] => move |l| {
@@ -115,12 +116,18 @@ impl SimpleComponent for OverviewModel {
                     },
 
                     // TODO: Just show omitted
-                    attach[0, 3, 1, 1] = &gtk::Label {
+                    attach[0, 3, 1, 1] = &gtk::Button::with_label("Random Keypair") {
+                        set_halign: gtk::Align::Start,
+                        connect_clicked[sender] => move |_| {
+                            sender.input(Self::Input::SetInterface(InterfaceSetKind::PrivateKey, Some(generate_private_key().unwrap())));
+                        }
+                    },
+                    attach[1, 3, 1, 1] = &gtk::Label {
                         set_label: "PrivateKey:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "private_key"]
-                    attach[1, 3, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 3, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.private_key),
                         connect_editing_notify[sender] => move |l| {
@@ -131,12 +138,22 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 4, 1, 1] = &gtk::Label {
+                    attach[1, 4, 1, 1] = &gtk::Label {
+                        set_label: "PublicKey:",
+                        set_halign: gtk::Align::Start,
+                    },
+                    #[name = "public_key"]
+                    attach[2, 4, 1, 1] = &gtk::EditableLabel {
+                        #[watch]
+                        set_text: &generate_public_key(get_value(&model.interface.private_key).to_owned()).unwrap(),
+                    },
+
+                    attach[1, 5, 1, 1] = &gtk::Label {
                         set_label: "DNS:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "dns"]
-                    attach[1, 4, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 5, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.dns),
                         connect_editing_notify[sender] => move |l| {
@@ -147,12 +164,12 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 5, 1, 1] = &gtk::Label {
+                    attach[1, 6, 1, 1] = &gtk::Label {
                         set_label: "Table:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "table"]
-                    attach[1, 5, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 6, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.table),
                         connect_editing_notify[sender] => move |l| {
@@ -163,12 +180,12 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 6, 1, 1] = &gtk::Label {
+                    attach[1, 7, 1, 1] = &gtk::Label {
                         set_label: "MTU:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "mtu"]
-                    attach[1, 6, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 7, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.mtu),
                         connect_editing_notify[sender] => move |l| {
@@ -179,12 +196,12 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 7, 1, 1] = &gtk::Label {
+                    attach[1, 8, 1, 1] = &gtk::Label {
                         set_label: "PreUp:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "pre_up"]
-                    attach[1, 7, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 8, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.pre_up),
                         connect_editing_notify[sender] => move |l| {
@@ -195,12 +212,12 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 8, 1, 1] = &gtk::Label {
+                    attach[1, 9, 1, 1] = &gtk::Label {
                         set_label: "PostUp:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "post_up"]
-                    attach[1, 8, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 9, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.post_up),
                         connect_editing_notify[sender] => move |l| {
@@ -211,12 +228,12 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 9, 1, 1] = &gtk::Label {
+                    attach[1, 10, 1, 1] = &gtk::Label {
                         set_label: "PreDown:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "pre_down"]
-                    attach[1, 9, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 10, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.pre_down),
                         connect_editing_notify[sender] => move |l| {
@@ -227,12 +244,12 @@ impl SimpleComponent for OverviewModel {
                         },
                     },
 
-                    attach[0, 10, 1, 1] = &gtk::Label {
+                    attach[1, 11, 1, 1] = &gtk::Label {
                         set_label: "PostDown:",
                         set_halign: gtk::Align::Start,
                     },
                     #[name = "post_down"]
-                    attach[1, 10, 1, 1] = &gtk::EditableLabel {
+                    attach[2, 11, 1, 1] = &gtk::EditableLabel {
                         #[watch]
                         set_text: get_value(&model.interface.post_down),
                         connect_editing_notify[sender] => move |l| {

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -2,6 +2,7 @@ use gtk::prelude::*;
 use relm4::prelude::*;
 
 use crate::config::*;
+use crate::utils::*;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Default, Clone)]
 pub struct PeerComp {
@@ -20,6 +21,7 @@ pub enum PeerSetKind {
     AllowedIps,
     Endpoint,
     PublicKey,
+    PresharedKey,
     PersistentKeepalive,
 }
 
@@ -64,11 +66,11 @@ impl FactoryComponent for PeerComp {
                 set_column_spacing: 5,
                 set_margin_all: 5,
 
-                attach[0, 0, 1, 1] = &gtk::Label {
+                attach[1, 0, 1, 1] = &gtk::Label {
                     set_label: "# Name:",
                     set_halign: gtk::Align::Start,
                 },
-                attach[1, 0, 1, 1] = &gtk::EditableLabel {
+                attach[2, 0, 1, 1] = &gtk::EditableLabel {
                     #[watch]
                     set_text: get_value(&self.peer.name),
                     connect_editing_notify[sender] => move |l| {
@@ -79,11 +81,11 @@ impl FactoryComponent for PeerComp {
                     },
                 },
 
-                attach[0, 1, 1, 1] = &gtk::Label {
+                attach[1, 1, 1, 1] = &gtk::Label {
                     set_label: "AllowedIPs:",
                     set_halign: gtk::Align::Start,
                 },
-                attach[1, 1, 1, 1] = &gtk::EditableLabel {
+                attach[2, 1, 1, 1] = &gtk::EditableLabel {
                     set_text: get_value(&self.peer.allowed_ips),
                     connect_editing_notify[sender] => move |l| {
                         if !l.is_editing() {
@@ -93,11 +95,11 @@ impl FactoryComponent for PeerComp {
                     },
                 },
 
-                attach[0, 2, 1, 1] = &gtk::Label {
+                attach[1, 2, 1, 1] = &gtk::Label {
                     set_label: "Endpoint:",
                     set_halign: gtk::Align::Start,
                 },
-                attach[1, 2, 1, 1] = &gtk::EditableLabel {
+                attach[2, 2, 1, 1] = &gtk::EditableLabel {
                     set_text: get_value(&self.peer.endpoint),
                     connect_editing_notify[sender] => move |l| {
                         if !l.is_editing() {
@@ -107,11 +109,11 @@ impl FactoryComponent for PeerComp {
                     },
                 },
 
-                attach[0, 3, 1, 1] = &gtk::Label {
+                attach[1, 3, 1, 1] = &gtk::Label {
                     set_label: "PublicKey:",
                     set_halign: gtk::Align::Start,
                 },
-                attach[1, 3, 1, 1] = &gtk::EditableLabel {
+                attach[2, 3, 1, 1] = &gtk::EditableLabel {
                     set_text: get_value(&self.peer.public_key),
                     connect_editing_notify[sender] => move |l| {
                         if !l.is_editing() {
@@ -121,11 +123,31 @@ impl FactoryComponent for PeerComp {
                     },
                 },
 
-                attach[0, 4, 1, 1] = &gtk::Label {
+                attach[0, 4, 1, 1] = &gtk::Button::with_label("Random PSK") {
+                    set_halign: gtk::Align::Start,
+                    connect_clicked[sender] => move |_| {
+                        sender.input(Self::Input::Set(PeerSetKind::PresharedKey, Some(generate_preshared_key().unwrap())));
+                    }
+                },
+                attach[1, 4, 1, 1] = &gtk::Label {
+                    set_label: "PresharedKey:",
+                    set_halign: gtk::Align::Start,
+                },
+                attach[2, 4, 1, 1] = &gtk::EditableLabel {
+                    set_text: get_value(&self.peer.preshared_key),
+                    connect_editing_notify[sender] => move |l| {
+                        if !l.is_editing() {
+                            let new: String = l.text().trim().into();
+                            sender.input(Self::Input::Set(PeerSetKind::PresharedKey, (new != "unknown").then_some(new)));
+                        }
+                    },
+                },
+
+                attach[1, 5, 1, 1] = &gtk::Label {
                     set_label: "PersistentKeepalive:",
                     set_halign: gtk::Align::Start,
                 },
-                attach[1, 4, 1, 1] = &gtk::EditableLabel {
+                attach[2, 5, 1, 1] = &gtk::EditableLabel {
                     set_text: get_value(&self.peer.persistent_keepalive),
                     connect_editing_notify[sender] => move |l| {
                         if !l.is_editing() {
@@ -153,6 +175,7 @@ impl FactoryComponent for PeerComp {
                 PeerSetKind::AllowedIps => self.peer.allowed_ips = value,
                 PeerSetKind::Endpoint => self.peer.endpoint = value,
                 PeerSetKind::PublicKey => self.peer.public_key = value,
+                PeerSetKind::PresharedKey => self.peer.preshared_key = value,
                 PeerSetKind::PersistentKeepalive => self.peer.persistent_keepalive = value,
             },
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,3 +64,14 @@ pub fn generate_public_key(priv_key: String) -> Result<String> {
             )
         })
 }
+
+pub fn generate_preshared_key() -> Result<String> {
+    let output = Command::new("wg")
+        .arg("genpsk")
+        .stdout(Stdio::piped())
+        .output()?;
+
+    String::from_utf8(output.stdout)
+        .map(|s| s.trim().into())
+        .map_err(|_| io::Error::other("Could not convert output of `wg genpsk` to utf-8 string."))
+}


### PR DESCRIPTION
Also add buttons to enable user to generate random keypair and PSK from UI. User public key will be visible also so that it can be copied to clipboard.

Fix legacy package naming in flake.nix.